### PR TITLE
Fix for infinite loop in currency input.

### DIFF
--- a/ts/components/inputs/currency.ts
+++ b/ts/components/inputs/currency.ts
@@ -24,6 +24,9 @@ export default class Currency extends AlpineComponent {
 
   entangleable = new Entangleable<string|number|null>()
 
+  // This is used to prevent the input from being formatted again and causing an infinite loop
+  tangleIgnoreNextInput = false
+
   get value (): string|number|null {
     return this.$props.emitFormatted
       ? this.input
@@ -32,6 +35,10 @@ export default class Currency extends AlpineComponent {
 
   init () {
     this.entangleable.watch(value => {
+      if (this.tangleIgnoreNextInput) {
+        this.tangleIgnoreNextInput = false
+        return
+      }
       this.input = this.$props.emitFormatted
         ? String(value)
         : this.mask(value)
@@ -39,7 +46,7 @@ export default class Currency extends AlpineComponent {
 
     this.$watch('input', () => {
       this.input = this.mask(this.input)
-
+      this.tangleIgnoreNextInput = true
       this.entangleable.set(this.value)
     })
 


### PR DESCRIPTION
### Description
When entering a "-" first the input will get stuck in an infinite loop and crash the browser tab.

### Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/wireui/wireui/blob/main/contributing.md) guide
- [x] I have added tests that prove my fix is effective or that my feature works (This is currently used in my prod app)
- [x] I have not added tests, the reason is: No other tests for these kind of inputs exist.
- [x] I have added the necessary documentation (if appropriate)
- [x] I have created a branch (PR from **main** branch will be closed)
- [x] New and existing unit tests pass **locally** with my changes
- [x] The PR does not contain multiple unrelated changes

### Issue Reference
N/A

### Screenshots
N/A